### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flake-checker.yml
+++ b/.github/workflows/flake-checker.yml
@@ -2,6 +2,8 @@ on:
   pull_request:
   push:
     branches: [main]
+permissions:
+  contents: read
 jobs:
   build:
     name: Check inputs


### PR DESCRIPTION
Potential fix for [https://github.com/suasuasuasuasua/nixos-config/security/code-scanning/2](https://github.com/suasuasuasuasua/nixos-config/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block specifying the minimal required permissions. In this case, the workflow simply checks out code and runs an action to check Nix flake inputs, neither of which require more than read access to repository contents. The best approach is to add a `permissions: contents: read` block at the workflow root (just after `on:`). This sets the minimum permission for all jobs unless overridden, following GitHub Action best practices.

You should add the following lines after the `on:` block and before `jobs:`:
```yaml
permissions:
  contents: read
```

No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
