### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build & test NixOS/Darwin configurations
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/suasuasuasuasua/nixos-config/security/code-scanning/1](https://github.com/suasuasuasuasua/nixos-config/security/code-scanning/1)

To fix the problem, you should add an explicit `permissions` block to the workflow that limits the permissions granted to the `GITHUB_TOKEN`. The minimal permission needed for build and test workflows is usually `contents: read`, unless write access to issues, pull requests, or other resources is required (none is shown here). The best place to insert the `permissions` block is near the top-level of the workflow, immediately under the `name:` or `on:` key, so it applies to all jobs in the workflow unless overridden locally. You only need to edit the `.github/workflows/build.yml` file as shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
